### PR TITLE
filter posts by subdirectory

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "Stoubord Labs"
 
 # Novela settings
-theme = "github.com/forestryio/hugo-theme-novela"
+theme = "hugo-theme-novela-master"
 
 # Internal Nav
 sectionPagesMenu = "mainmenu"

--- a/themes/hugo-theme-novela-master/layouts/partials/articles/list.html
+++ b/themes/hugo-theme-novela-master/layouts/partials/articles/list.html
@@ -1,6 +1,6 @@
 <section class="section nartrow">
     <div id="articlesList" class="articles-list-container show-details">
-        {{ $posts := partialCached "func/GetArticles" . "articles" }}
+        {{ $posts := partialCached "func/GetArticles" . .Type }}
         {{ $paginator := .Paginate $posts }}
         {{ $biggerFirst := true }}
         {{ $biggerPlaced := false }}

--- a/themes/hugo-theme-novela-master/layouts/partials/func/GetArticles.html
+++ b/themes/hugo-theme-novela-master/layouts/partials/func/GetArticles.html
@@ -15,7 +15,7 @@
     {{ $articles := partialCached "func/GetArticles" . "articles" }}
 */}}
 {{ $articles := slice }}
-{{ with where site.RegularPages "Type" "post" }}
+{{ with where site.RegularPages "Type" .Type }}
   {{ $articles = . }}
 {{ end }}
 {{ return $articles }}


### PR DESCRIPTION
The default main menu does not seem to work now, but each of the subdirectories do.

There is probably a null-coalescing operator or conditional in Go or the theme language that can replace .Type==null with "posts" or "articles".